### PR TITLE
Fix EU daily stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This tap:
 [eu_daily](https://github.com/covid19-eu-zh/covid19-eu-data/tree/master/dataset/daily)
 - Repository: covid19-eu-zh/covid19-eu-data
 - Folder: dataset/daily/
-- Search Endpoint: https://api.github.com/search/code?q=-filename:ecdc+path:dataset+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc
+- Search Endpoint: https://api.github.com/search/code?q=-filename:ecdc+path:dataset/daily+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc
   - Exclude: ecdc folder/files
 - File Endpoint: https://api.github.com/repos/covid19-eu-zh/covid19-eu-data/contents/[GIT_FILE_PATH]
 - Primary key fields: git_path, row_number

--- a/tap_covid_19/schemas/c19_trk_us_states_info.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_info.json
@@ -33,13 +33,13 @@
     "state": {
       "type": ["null", "string"]
     },
-    "covid_19_site_old": {
+    "covid19_site_old": {
       "type": ["null", "string"]
     },
-    "covid_19_site": {
+    "covid19_site": {
       "type": ["null", "string"]
     },
-    "covid_19_site_secondary": {
+    "covid19_site_secondary": {
       "type": ["null", "string"]
     },
     "twitter": {

--- a/tap_covid_19/schemas/eu_daily.json
+++ b/tap_covid_19/schemas/eu_daily.json
@@ -30,10 +30,6 @@
       "row_number": {
         "type": ["null", "integer"]
       },
-      "source": {
-        "type": ["null", "string"],
-        "enum": ["country", "ecdc"]
-      },
       "date": {
         "type": ["null", "string"],
         "format": "date"

--- a/tap_covid_19/schemas/eu_ecdc_daily.json
+++ b/tap_covid_19/schemas/eu_ecdc_daily.json
@@ -30,10 +30,6 @@
       "row_number": {
         "type": ["null", "integer"]
       },
-      "source": {
-        "type": ["null", "string"],
-        "enum": ["country", "ecdc"]
-      },
       "date": {
         "type": ["null", "string"],
         "format": "date"
@@ -45,53 +41,11 @@
       "country": {
         "type": ["null", "string"]
       },
-      "nuts_1": {
-        "type": ["null", "string"]
-      },
-      "nuts_2": {
-        "type": ["null", "string"]
-      },
-      "nuts_3": {
-        "type": ["null", "string"]
-      },
-      "lau": {
-        "type": ["null", "string"]
-      },
       "cases": {
-        "type": ["null", "number"]
-      },
-      "cases_lower": {
-        "type": ["null", "integer"]
-      },
-      "cases_upper": {
-        "type": ["null", "integer"]
-      },
-      "population": {
-        "type": ["null", "number"]
-      },
-      "cases_100k_pop": {
-        "type": ["null", "number"]
-      },
-      "percent": {
         "type": ["null", "number"]
       },
       "deaths": {
         "type": ["null", "number"]
-      },
-      "recovered": {
-        "type": ["null", "integer"]
-      },
-      "hospitalized": {
-        "type": ["null", "number"]
-      },
-      "intensive_care": {
-        "type": ["null", "integer"]
-      },
-      "tests": {
-        "type": ["null", "integer"]
-      },
-      "quarantine": {
-        "type": ["null", "integer"]
       }
     }
   }

--- a/tap_covid_19/schemas/jh_csse_daily.json
+++ b/tap_covid_19/schemas/jh_csse_daily.json
@@ -83,9 +83,6 @@
     "admin_area": {
       "type": ["null", "string"]
     },
-    "county": {
-      "type": ["null", "string"]
-    },
     "is_a_cruise": {
       "type": ["null", "boolean"]
     }

--- a/tap_covid_19/schemas/neherlab_population.json
+++ b/tap_covid_19/schemas/neherlab_population.json
@@ -50,6 +50,9 @@
       },
       "imports_per_day": {
         "type": ["null", "number"]
+      },
+      "hemisphere": {
+        "type": ["null", "string"]
       }
     }
   }

--- a/tap_covid_19/schemas/nytimes_us_counties.json
+++ b/tap_covid_19/schemas/nytimes_us_counties.json
@@ -44,7 +44,7 @@
     "state": {
       "type": ["null", "string"]
     },
-    "state_name": {
+    "state_code": {
       "type": ["null", "string"]
     },
     "fips": {

--- a/tap_covid_19/schemas/nytimes_us_states.json
+++ b/tap_covid_19/schemas/nytimes_us_states.json
@@ -41,7 +41,7 @@
     "state": {
       "type": ["null", "string"]
     },
-    "state_name": {
+    "state_code": {
       "type": ["null", "string"]
     },
     "fips": {

--- a/tap_covid_19/streams.py
+++ b/tap_covid_19/streams.py
@@ -116,7 +116,7 @@ STREAMS = {
     # Many files w/ new files each day. Use INCREMENTAL replication only (NOT activate_version)
     # NOTE: -filename:ecdc in search_path means: exclude ecdc filenames
     'eu_daily': {
-        'search_path': 'search/code?q=-filename:ecdc+path:dataset+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc',
+        'search_path': 'search/code?q=-filename:ecdc+path:dataset/daily+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc',
         'data_key': 'items',
         'key_properties': ['git_path', 'row_number'],
         'replication_method': 'INCREMENTAL',

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -388,6 +388,39 @@ def transform_eu_daily(record):
     return new_record
 
 
+# Added by E. RAMIREZ
+def transform_eu_ecdc_daily(record):
+    new_record = {}
+
+    # Git file fields
+    file_name = record.get('git_file_name')
+    new_record = {}
+    new_record['git_owner'] = record.get('git_owner')
+    new_record['git_repository'] = record.get('git_repository')
+    new_record['git_url'] = record.get('git_url')
+    new_record['git_html_url'] = record.get('git_html_url')
+    new_record['git_path'] = record.get('git_path')
+    new_record['git_sha'] = record.get('git_sha')
+    new_record['git_file_name'] = file_name
+    new_record['git_last_modified'] = record.get('git_last_modified')
+    new_record['row_number'] = record.get('row_number')
+
+    # Datetime
+    dt_str = record.get('datetime')
+    dt = datetime.strptime(dt_str, '%Y-%m-%dT%H:%M:%S')
+    new_record['datetime'] = dt_str
+    new_record['date'] = dt.date()
+
+    unchanged_fields = [
+        'country',
+        'cases',
+        'deaths',
+    ]
+    new_record.update({f: record.get(f) for f in unchanged_fields})
+
+    return new_record
+
+
 # Added by J. SCOTT
 # Italy by National, Region, Province Daily
 # NOTES on the transformation :
@@ -741,8 +774,10 @@ def transform_neherlab_population(record):
 def transform_record(stream_name, record):
     if stream_name == 'jh_csse_daily':
         new_record = transform_jh_csse_daily(record)
-    elif stream_name in ('eu_daily', 'eu_ecdc_daily)'):
+    elif stream_name in 'eu_daily':
         new_record = transform_eu_daily(record)
+    elif stream_name in 'eu_ecdc_daily':
+        new_record = transform_eu_ecdc_daily(record)
     elif stream_name[:5] == 'italy':
         new_record = transform_italy_daily(record)
     elif stream_name in ('nytimes_us_states', 'nytimes_us_counties'):

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -327,11 +327,10 @@ def transform_c19_trk(record):
     return new_record
 
 
-# Added by E. RAMIEREZ
+# Added by E. RAMIREZ
 def transform_eu_daily(record):
     new_record = {}
 
-    # Git file fields
     # Git file fields
     file_name = record.get('git_file_name')
     new_record = {}
@@ -361,14 +360,6 @@ def transform_eu_daily(record):
 
     # Report fields
     new_record['cases_100k_pop'] = record.get('cases/100k pop.')
-
-    # ECDC files
-    new_record['source'] = 'ecdc' if file_name.startswith('ecdc') else 'country'
-    country = record.get('country')
-
-    # Skip totals for ECDC files
-    if country == 'Total':
-        return None
 
     cases = record.get('cases')
     # e.g. "1 to 4"

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -700,9 +700,8 @@ def transform_nytimes(record):
     new_record['datetime'] = dttm_str
 
     # For US State code lookup
-    abbrev_us_state = dict(map(reversed, us_state_abbrev.items()))
-    state_code = record.get('state')
-    new_record['state_name'] = abbrev_us_state.get(state_code)
+    state_name = record.get('state')
+    new_record['state_code'] = us_state_abbrev.get(state_name)
 
     return new_record
 

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -441,12 +441,12 @@ def transform_italy_daily(record):
     intensive_care_keys = ['terapia_intensiva']
     total_hospitalized_keys = ['totale_ospedalizzati']
     home_isolation_keys = ['isolamento_domiciliare']
-    total_currently_positive_keys = ['totale_attualmente_positivi']
-    new_currently_positive_keys = ['nuovi_attualmente_positivi']
+    total_currently_positive_keys = ['totale_attualmente_positivi', 'totale_positivi']
+    new_currently_positive_keys = ['nuovi_attualmente_positivi', 'nuovi_positivi']
     discharged_recovered_keys = ['dimessi_guariti']
     deaths_keys = ['deceduti']
     total_cases_keys = ['totale_casi']
-    tests_performed_keys= ['tamponi']
+    tested_keys= ['tamponi']
     note_it_keys = ['note_it']
     note_en_keys = ['note_en']
 
@@ -461,12 +461,12 @@ def transform_italy_daily(record):
         {'it': 'terapia_intensiva',             'en': 'intensive_care'},
         {'it': 'totale_ospedalizzati',          'en': 'total_hospitalized'},
         {'it': 'isolamento_domiciliare',        'en': 'home_isolation'},
-        {'it': 'totale_attualmente_positivi',   'en': 'total_currently_positive'},
-        {'it': 'nuovi_attualmente_positivi',    'en': 'new_currently_positive'},
+        {'it': 'totale_positivi',               'en': 'total_currently_positive'},
+        {'it': 'nuovi_positivi',                'en': 'new_currently_positive'},
         {'it': 'dimessi_guariti',               'en': 'discharged_recovered'},
         {'it': 'deceduti',                      'en': 'deaths'},
         {'it': 'totale_casi',                   'en': 'total_cases'},
-        {'it': 'tamponi',                       'en': 'tests_performed'},
+        {'it': 'tamponi',                       'en': 'tested'},
         {'it': 'note_it',                       'en': 'note_it'},
         {'it': 'note_en',                       'en': 'note_en'},
         # Regional Add'l Fields
@@ -562,7 +562,7 @@ def transform_italy_daily(record):
                 pass
             if new_val == 0.0:
                 new_val = None
-            new_record['latitude'] = new_val
+            new_record['lat'] = new_val
 
         # longitude (long) is a float
         elif key in longitude_keys:
@@ -573,7 +573,7 @@ def transform_italy_daily(record):
                 pass
             if new_val == 0.0:
                 new_val = None
-            new_record['longitude'] = new_val
+            new_record['long'] = new_val
 
         # hospitalized_with_symptoms (ricoverati_con_sintomi) is an integer
         elif key in hospitalized_with_symptoms_keys:
@@ -582,7 +582,7 @@ def transform_italy_daily(record):
             except Exception as err:
                 new_val = 0
                 pass
-            new_record['hospitalized_with_symptoms_keys'] = new_val
+            new_record['hospitalized_with_symptoms'] = new_val
 
         # intensive_care (terapia_intensiva) is an integer
         elif key in intensive_care_keys:
@@ -656,14 +656,14 @@ def transform_italy_daily(record):
                 pass
             new_record['total_cases'] = new_val
 
-        # tests_performed (tamponi) is an integer
-        elif key in tests_performed_keys:
+        # tested (tamponi) is an integer
+        elif key in tested_keys:
             try:
                 new_val = int(val)
             except Exception as err:
                 new_val = 0
                 pass
-            new_record['tests_performed'] = new_val
+            new_record['tested'] = new_val
 
         # notes in italian
         elif key in note_it_keys:

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -787,7 +787,7 @@ def transform_record(stream_name, record):
     elif stream_name == 'neherlab_country_codes':
         new_record = transform_neherlab_country_codes(record)
     elif stream_name == 'neherlab_population':
-        new_record = transform_neherlab_country_codes(record)
+        new_record = transform_neherlab_population(record)
     elif stream_name[:7] == 'c19_trk':
         new_record = transform_c19_trk(record)
 

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -730,6 +730,9 @@ def transform_neherlab_case_counts(record):
     new_record['datetime'] = dttm_str
     new_record.pop('time', None)
 
+    new_record['icu'] = new_record.get('ICU')
+    new_record.pop('ICU', None)
+
     if not record.get('location'):
         # Get location from Git path
         new_record['location'] = record.get('git_path').replace(

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -140,7 +140,6 @@ def transform_jh_csse_daily(record):
 
     # Loop thru keys/values
     is_a_cruise = False
-    county = None
     for key, val in list(record.items()):
         # Trim keys
         key = str(key).strip()
@@ -178,8 +177,6 @@ def transform_jh_csse_daily(record):
                 for value in vals:
                     # Trim new_val
                     new_val = str(value).strip()
-                    if 'county' in new_val.lower():
-                        county = new_val.replace('County', '').replace('county', '').strip()
 
                     # Lookup State code to get State Name
                     state = abbrev_us_state.get(new_val)


### PR DESCRIPTION
# Description of change

Fixes and improvements:

-  EU daily files GitHub search path
- Remove `source` field from EU and ECDC schemas
- Added an individual transform function for ECDC records
- Removed unused fields in ECDC schema

# Manual QA steps
 I tested this both with `singer-check-tap` and `target-postgres`. The resulting data in Postgres can be queried to validate the data.

## ECDC totals validation

Query:

```sql
WITH
country_totals AS (
    SELECT SUM(cases) AS cases,
           SUM(deaths) AS deaths
      FROM eu_ecdc_daily
     WHERE datetime = (SELECT MAX(datetime) FROM eu_ecdc_daily)
       AND country <> 'Total'
),
total_totals AS (
    SELECT cases,
           deaths
      FROM eu_ecdc_daily
     WHERE datetime = (SELECT MAX(datetime) FROM eu_ecdc_daily)
       AND country = 'Total'
)

SELECT 'Countries Sum' AS source, * FROM country_totals
UNION
SELECT 'Totals Sum' AS source,* FROM total_totals;
```

Output:

|    source     | cases  | deaths |
|:-------------:|:------:|-------:|
| Countries Sum | 421808 |  29350 |
| Totals Sum    | 421808 |  29350 |

##  File counts per country

Query:

```sql
WITH
git_path_count AS (
    SELECT DISTINCT split_part(git_path, '/', 3) AS country,
           COUNT(DISTINCT git_path) AS file_count
      FROM eu_daily
     GROUP BY 1
     ORDER BY 1
),
country_count AS (
    SELECT LOWER(country) AS country,
           COUNT(DISTINCT git_path) AS file_count
      FROM eu_daily
     GROUP BY 1
     ORDER BY 1
)

SELECT g.country,
       g.file_count AS count_by_path,
       c.file_count AS count_by_country
  FROM git_path_count AS g
  JOIN country_count AS c
 USING(country);
```

Output:

| country  | count_by_path | count_by_country |
|:--------:|:-------------:|------------------|
| at       |            56 |               56 |
| ch       |            22 |               22 |
| cz       |            37 |               37 |
| de       |            42 |               42 |
| england  |            17 |               17 |
| fr       |            16 |               16 |
| hu       |             9 |                9 |
| it       |            38 |               38 |
| nl       |            29 |               29 |
| no       |            13 |               13 |
| pl       |            15 |               15 |
| scotland |            17 |               17 |
| se       |            18 |               18 |
| si       |             3 |                3 |
| uk       |             6 |                6 |
| wales    |            15 |               15 |

## ECDC files

Query:

```sql
SELECT DISTINCT git_path
  FROM eu_ecdc_daily
 ORDER BY 1;
```

Output:

|                      git_path                       |
|:---------------------------------------------------:|
| dataset/daily/ecdc/ecdc_covid19_2020-03-19_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-20_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-21_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-22_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-23_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-24_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-25_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-26_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-27_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-28_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-29_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-30_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-03-31_0_00.csv |
| dataset/daily/ecdc/ecdc_covid19_2020-04-01_0_00.csv |

# Risks
 - 
 
# Rollback steps
 - revert this branch
