### PR TITLE
v.0.0.8 row_number, 403 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.8
+  * Change field `row_number` (a reserved word in Redshift) to `__sdc_row_number`. This requires dropping/re-loading tables in downstream target. Added 403 error handling for API Abuse Detection to wait for 2 minutes before resuming requests. Add endpoint: `neherlab_icu_capacity`.
+
+## 0.0.7
+  * Functional testing and validation changes to fields, streams, transforms.
+
 ## 0.0.6
   * Adjust `streams.py` and `sync.py` logic for `activate_version` based on source data replication strategy: single files vs. multiple files daily.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This tap:
 - Search Endpoint: https://api.github.com/search/code?q=-filename:ecdc+path:dataset/daily+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc
   - Exclude: ecdc folder/files
 - File Endpoint: https://api.github.com/repos/covid19-eu-zh/covid19-eu-data/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new files each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse eu_daily_file content, get date from table datetime, merge differing column sets, convert to JSON
@@ -60,7 +60,7 @@ This tap:
 - Folder: dataset/daily/ecdc
 - Search Endpoint: https://api.github.com/search/code?q=filename:ecdc+path:dataset/daily/ecdc+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc
 - File Endpoint: https://api.github.com/repos/covid19-eu-zh/covid19-eu-data/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new file each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse eu_daily_file content, get date from table datetime, merge differing column sets, convert to JSON
@@ -72,7 +72,7 @@ This tap:
 - Search Endpoint: hhttps://api.github.com/search/code?q=path:dati-andamento-nazionale+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=asc
   - exclude: current files
 - File Endpoint: https://api.github.com/repos/pcm-dpc/COVID-19/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new file each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse italy_national_daily content, cleanse location fields, and convert to JSON
@@ -83,7 +83,7 @@ This tap:
 - Search Endpoint: https://api.github.com/search/code?q=path:dati-regioni+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=asc
   - Exclude current files
 - File Endpoint: https://api.github.com/repos/pcm-dpc/COVID-19/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new files each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse italy_regional_daily content, cleanse location fields, and convert to JSON
@@ -94,7 +94,7 @@ This tap:
 - Search Endpoint: https://api.github.com/search/code?q=path:dati-province+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=asc
   - Exclude: current files
 - File Endpoint: https://api.github.com/repos/pcm-dpc/COVID-19/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new files each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse italy_provincial_daily content, cleanse location fields, and convert to JSON
@@ -104,7 +104,7 @@ This tap:
 - Folder: csse_covid_19_data/csse_covid_19_daily_reports
 - Search Endpoint: https://api.github.com/search/code?q=path:csse_covid_19_data/csse_covid_19_daily_reports+extension:csv+repo:CSSEGISandData/COVID-19&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/CSSEGISandData/COVID-19/contents/[GIT_FILE_PATH]
-- Primary key fields: git_path, row_number
+- Primary key fields: git_path, __sdc_row_number
 - Replication strategy: Many files w/ new file each day. Use INCREMENTAL replication only (NOT activate_version).
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, Decode, parse jh_daily_file content, cleanse location fields, and convert to JSON
@@ -114,7 +114,7 @@ This tap:
 - Folder: . (root folder)
 - Search Endpoint: https://api.github.com/search/code?q=filename:us-states+extension:csv+repo:nytimes/covid-19-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/nytimes/covid-19-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ daily updates (additional rows). Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us-states content and convert to JSON, lookup state_name
@@ -124,7 +124,7 @@ This tap:
 - Folder: . (root folder)
 - Search Endpoint: https://api.github.com/search/code?q=filename:us-counties+extension:csv+repo:nytimes/covid-19-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/nytimes/covid-19-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ daily updates (additional rows). Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us-counties content and convert to JSON, lookup state_name
@@ -134,7 +134,7 @@ This tap:
 - Folder: data
 - Search Endpoint: https://api.github.com/search/code?q=path:data+filename:state_current+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/covid-tracking-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ daily updates (additional rows). Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse states_current content and convert to JSON, camelCase to snake_case field keys
@@ -144,7 +144,7 @@ This tap:
 - Folder: data
 - Search Endpoint: https://api.github.com/search/code?q=path:data+filename:states_daily_4pm_et+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/covid-tracking-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ daily updates (updated rows). Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse states_daily content and convert to JSON, camelCase to snake_case field keys
@@ -154,7 +154,7 @@ This tap:
 - Folder: data
 - Search Endpoint: https://api.github.com/search/code?q=path:data+filename:states_info+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/covid-tracking-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ occasional updates (updated rows). Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, ecode, parse states_info content and convert to JSON, camelCase to snake_case field keys
@@ -165,7 +165,7 @@ This tap:
 - Search Endpoint: https://api.github.com/search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_states+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=asc
     - Exclude: agegroups file
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/associated-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ minimal updates. Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us_population_states content and convert to JSON, camelCase to snake_case field keys
@@ -175,7 +175,7 @@ This tap:
 - Folder: us_census_data
 - Search Endpoint: https://api.github.com/search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_states_agegroups+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/associated-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ minimal updates. Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us_population_states_age_groups content and convert to JSON, camelCase to snake_case field keys
@@ -185,7 +185,7 @@ This tap:
 - Folder: us_census_data
 - Search Endpoint: https://api.github.com/search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_counties+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/associated-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ minimal updates. Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us_population_counties content and convert to JSON, camelCase to snake_case field keys
@@ -195,7 +195,7 @@ This tap:
 - Folder: acs_health_insurance
 - Search Endpoint: https://api.github.com/search/code?q=path:acs_health_insurance+filename:acs_2018_health_insurance_coverage_estimates+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/associated-data/contents/[GIT_FILE_PATH]
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ minimal updates. Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us_acs_health_insurance content and convert to JSON, camelCase to snake_case field keys
@@ -206,7 +206,7 @@ This tap:
 - Search Endpoint: https://api.github.com/search/code?q=path:kff_hospital_beds+filename:kff_usa_hospital_beds_per_capita_2018+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=asc
 - File Endpoint: https://api.github.com/repos/COVID19Tracking/associated-data/contents/[GIT_FILE_PATH]
 - Original Sourc: KFF (Kaiser Family Foundation)
-- Primary key fields: row_number
+- Primary key fields: __sdc_row_number
 - Replication strategy: Single file w/ minimal updates. Use FULL_TABLE replication w/ activate_version.
   - Bookmark field: git_last_modified
 - Transformations: Remove content node, add repository fields, decode, parse us_kff_hospital_beds content and convert to JSON, camelCase to snake_case field keys
@@ -255,7 +255,7 @@ Even though this tap pulls from public GitHub repositories, API request limits a
     
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
     The `...files` streams use a datetime bookmark based on the GitHub `last_modified` datetime of the file that is returned in the GET header response.
-    The `csv-data` streams us an integer bookmark based on the UNIX epoch time when the file batch was last sent. This is used with the `row_number` as a part of the Singer.io [Activate Version](https://github.com/singer-io/singer-python/blob/master/singer/messages.py#L137) logic to insert/update and delete the delta (when the new batch has fewer records).
+    The `csv-data` streams us an integer bookmark based on the UNIX epoch time when the file batch was last sent. This is used with the `__sdc_row_number` as a part of the Singer.io [Activate Version](https://github.com/singer-io/singer-python/blob/master/singer/messages.py#L137) logic to insert/update and delete the delta (when the new batch has fewer records).
 
     ```json
     {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-covid-19',
-      version='0.0.7',
+      version='0.0.8',
       description='Singer.io tap for extracting COVID-19 CSV data files with the GitHub API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_covid_19/schemas/c19_trk_us_daily.json
+++ b/tap_covid_19/schemas/c19_trk_us_daily.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "date": {

--- a/tap_covid_19/schemas/c19_trk_us_population_counties.json
+++ b/tap_covid_19/schemas/c19_trk_us_population_counties.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/c19_trk_us_population_states.json
+++ b/tap_covid_19/schemas/c19_trk_us_population_states.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/c19_trk_us_population_states_age_groups.json
+++ b/tap_covid_19/schemas/c19_trk_us_population_states_age_groups.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/c19_trk_us_states_acs_health_insurance.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_acs_health_insurance.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "geo_id": {

--- a/tap_covid_19/schemas/c19_trk_us_states_current.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_current.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/c19_trk_us_states_daily.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_daily.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "date": {

--- a/tap_covid_19/schemas/c19_trk_us_states_info.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_info.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/c19_trk_us_states_kff_hospital_beds.json
+++ b/tap_covid_19/schemas/c19_trk_us_states_kff_hospital_beds.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "state": {

--- a/tap_covid_19/schemas/eu_daily.json
+++ b/tap_covid_19/schemas/eu_daily.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "date": {

--- a/tap_covid_19/schemas/eu_ecdc_daily.json
+++ b/tap_covid_19/schemas/eu_ecdc_daily.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "date": {

--- a/tap_covid_19/schemas/italy_national_daily.json
+++ b/tap_covid_19/schemas/italy_national_daily.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "date": {

--- a/tap_covid_19/schemas/italy_provincial_daily.json
+++ b/tap_covid_19/schemas/italy_provincial_daily.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "date": {

--- a/tap_covid_19/schemas/italy_regional_daily.json
+++ b/tap_covid_19/schemas/italy_regional_daily.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "date": {

--- a/tap_covid_19/schemas/jh_csse_daily.json
+++ b/tap_covid_19/schemas/jh_csse_daily.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "date": {

--- a/tap_covid_19/schemas/neherlab_case_counts.json
+++ b/tap_covid_19/schemas/neherlab_case_counts.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "location": {

--- a/tap_covid_19/schemas/neherlab_icu_capacity.json
+++ b/tap_covid_19/schemas/neherlab_icu_capacity.json
@@ -30,38 +30,32 @@
       "__sdc_row_number": {
         "type": ["null", "integer"]
       },
-      "name": {
+      "country": {
         "type": ["null", "string"]
       },
-      "alpha_2": {
-        "type": ["null", "string"]
+      "acute_care": {
+        "type": ["null", "integer"]
       },
-      "alpha_3": {
-        "type": ["null", "string"]
+      "acute_care_per_100k": {
+        "type": ["null", "integer"]
       },
-      "country_code": {
-        "type": ["null", "string"]
+      "imcu": {
+        "type": ["null", "integer"]
       },
-      "iso_3166_2": {
-        "type": ["null", "string"]
+      "icu": {
+        "type": ["null", "integer"]
       },
-      "region": {
-        "type": ["null", "string"]
+      "critical_care": {
+        "type": ["null", "integer"]
       },
-      "sub_region": {
-        "type": ["null", "string"]
+      "critical_care_per_100k": {
+        "type": ["null", "number"]
       },
-      "intermediate_region": {
-        "type": ["null", "string"]
+      "percent_of_total": {
+        "type": ["null", "number"]
       },
-      "region_code": {
-        "type": ["null", "string"]
-      },
-      "sub_region_code": {
-        "type": ["null", "string"]
-      },
-      "intermediate_region_code": {
-        "type": ["null", "string"]
+      "gdp": {
+        "type": ["null", "number"]
       }
     }
   }

--- a/tap_covid_19/schemas/neherlab_population.json
+++ b/tap_covid_19/schemas/neherlab_population.json
@@ -27,7 +27,7 @@
         "type": ["null", "string"],
         "format": "date-time"
       },
-      "row_number": {
+      "__sdc_row_number": {
         "type": ["null", "integer"]
       },
       "name": {

--- a/tap_covid_19/schemas/nytimes_us_counties.json
+++ b/tap_covid_19/schemas/nytimes_us_counties.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "date": {

--- a/tap_covid_19/schemas/nytimes_us_states.json
+++ b/tap_covid_19/schemas/nytimes_us_states.json
@@ -27,7 +27,7 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
-    "row_number": {
+    "__sdc_row_number": {
       "type": ["null", "integer"]
     },
     "date": {

--- a/tap_covid_19/streams.py
+++ b/tap_covid_19/streams.py
@@ -17,7 +17,7 @@ STREAMS = {
     'c19_trk_us_daily': {
         'search_path': 'search/code?q=filename:us_daily+extension:csv+path:data+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -28,7 +28,7 @@ STREAMS = {
     'c19_trk_us_states_current': {
         'search_path': 'search/code?q=path:data+filename:states_current+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -39,7 +39,7 @@ STREAMS = {
     'c19_trk_us_states_daily': {
         'search_path': 'search/code?q=path:data+filename:states_daily_4pm_et+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -50,7 +50,7 @@ STREAMS = {
     'c19_trk_us_states_info': {
         'search_path': 'search/code?q=path:data+filename:states_info+extension:csv+repo:COVID19Tracking/covid-tracking-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -61,7 +61,7 @@ STREAMS = {
     'c19_trk_us_population_counties': {
         'search_path': 'search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_counties+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -72,7 +72,7 @@ STREAMS = {
     'c19_trk_us_population_states_age_groups': {
         'search_path': 'search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_states_agegroups+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -84,7 +84,7 @@ STREAMS = {
         'search_path': 'search/code?q=path:us_census_data+filename:us_census_2018_population_estimates_states+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=desc',
         'exclude_files': ['us_census_2018_population_estimates_states_agegroups.csv'],
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -95,7 +95,7 @@ STREAMS = {
     'c19_trk_us_states_kff_hospital_beds': {
         'search_path': 'search/code?q=path:kff_hospital_beds+filename:kff_usa_hospital_beds_per_capita_2018+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -106,7 +106,7 @@ STREAMS = {
     'c19_trk_us_states_acs_health_insurance': {
         'search_path': 'search/code?q=path:acs_health_insurance+filename:acs_2018_health_insurance_coverage_estimates+extension:csv+repo:COVID19Tracking/associated-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -118,7 +118,7 @@ STREAMS = {
     'eu_daily': {
         'search_path': 'search/code?q=-filename:ecdc+path:dataset/daily+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -129,7 +129,7 @@ STREAMS = {
     'eu_ecdc_daily': {
         'search_path': 'search/code?q=filename:ecdc+path:dataset/daily/ecdc+extension:csv+repo:covid19-eu-zh/covid19-eu-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -142,7 +142,7 @@ STREAMS = {
         'search_path': 'search/code?q=path:dati-andamento-nazionale+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=desc',
         'exclude_files': ['dpc-covid19-ita-andamento-nazionale-latest.csv', 'dpc-covid19-ita-andamento-nazionale.csv'],
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -155,7 +155,7 @@ STREAMS = {
         'search_path': 'search/code?q=path:dati-regioni+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=desc',
         'exclude_files': ['dpc-covid19-ita-regioni-latest.csv', 'dpc-covid19-ita-regioni.csv'],
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -168,7 +168,7 @@ STREAMS = {
         'search_path': 'search/code?q=path:dati-province+extension:csv+repo:pcm-dpc/COVID-19&sort=indexed&order=desc',
         'exclude_files': ['dpc-covid19-ita-province-latest.csv', 'dpc-covid19-ita-province.csv'],
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -179,7 +179,7 @@ STREAMS = {
     'jh_csse_daily': {
         'search_path': 'search/code?q=path:csse_covid_19_data/csse_covid_19_daily_reports+extension:csv+repo:CSSEGISandData/COVID-19&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -190,7 +190,7 @@ STREAMS = {
     'nytimes_us_states': {
         'search_path': 'search/code?q=filename:us-states+extension:csv+repo:nytimes/covid-19-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -201,7 +201,7 @@ STREAMS = {
     'nytimes_us_counties': {
         'search_path': 'search/code?q=filename:us-counties+extension:csv+repo:nytimes/covid-19-data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -212,7 +212,7 @@ STREAMS = {
     'neherlab_case_counts': {
         'search_path': 'search/code?q=path:case-counts+extension:tsv+repo:neherlab/covid19_scenarios_data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['git_path', '__sdc_row_number'],
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
@@ -225,7 +225,7 @@ STREAMS = {
     'neherlab_country_codes': {
         'search_path': 'search/code?q=filename:country_codes+extension:csv+repo:neherlab/covid19_scenarios_data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['row_number'],
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],
@@ -236,7 +236,19 @@ STREAMS = {
     'neherlab_population': {
         'search_path': 'search/code?q=filename:populationData+extension:tsv+repo:neherlab/covid19_scenarios_data&sort=indexed&order=desc',
         'data_key': 'items',
-        'key_properties': ['git_path', 'row_number'],
+        'key_properties': ['__sdc_row_number'],
+        'replication_method': 'FULL_TABLE',
+        'activate_version': True,
+        'replication_keys': ['git_last_modified'],
+        'bookmark_query_field': 'If-Modified-Since',
+        'csv_delimiter': '\t'
+    },
+    # Reference: https://github.com/neherlab/covid19_scenarios_data/blob/master/hospital-data/ICU_capacity.tsv
+    # Single file w/ minimal updates (additional rows). Use FULL_TABLE replication w/ activate_version
+    'neherlab_icu_capacity': {
+        'search_path': 'search/code?q=path:hospital-data+filename:ICU_capacity+extension:tsv+repo:neherlab/covid19_scenarios_data&sort=indexed&order=desc',
+        'data_key': 'items',
+        'key_properties': ['__sdc_row_number'],
         'replication_method': 'FULL_TABLE',
         'activate_version': True,
         'replication_keys': ['git_last_modified'],

--- a/tap_covid_19/sync.py
+++ b/tap_covid_19/sync.py
@@ -273,7 +273,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                         record['git_sha'] = file_sha
                         record['git_file_name'] = file_name
                         record['git_last_modified'] = commit_last_modified
-                        record['row_number'] = row_number
+                        record['__sdc_row_number'] = row_number
 
                         # Transform record and append
                         transformed_csv_record = {}

--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -124,7 +124,7 @@ def transform_jh_csse_daily(record):
     new_record['git_sha'] = record.get('git_sha')
     new_record['git_file_name'] = file_name
     new_record['git_last_modified'] = record.get('git_last_modified')
-    new_record['row_number'] = record.get('row_number')
+    new_record['__sdc_row_number'] = record.get('__sdc_row_number')
 
     # Date/Datetime from file_name
     timezone = pytz.timezone('UTC')
@@ -339,7 +339,7 @@ def transform_eu_daily(record):
     new_record['git_sha'] = record.get('git_sha')
     new_record['git_file_name'] = file_name
     new_record['git_last_modified'] = record.get('git_last_modified')
-    new_record['row_number'] = record.get('row_number')
+    new_record['__sdc_row_number'] = record.get('__sdc_row_number')
 
     # Datetime
     dt_str = record.get('datetime')
@@ -400,7 +400,7 @@ def transform_eu_ecdc_daily(record):
     new_record['git_sha'] = record.get('git_sha')
     new_record['git_file_name'] = file_name
     new_record['git_last_modified'] = record.get('git_last_modified')
-    new_record['row_number'] = record.get('row_number')
+    new_record['__sdc_row_number'] = record.get('__sdc_row_number')
 
     # Datetime
     dt_str = record.get('datetime')
@@ -489,7 +489,7 @@ def transform_italy_daily(record):
     new_record['git_sha'] = record.get('git_sha')
     new_record['git_file_name'] = file_name
     new_record['git_last_modified'] = record.get('git_last_modified')
-    new_record['row_number'] = record.get('row_number')
+    new_record['__sdc_row_number'] = record.get('__sdc_row_number')
 
     # Date/Datetime from file_name ( e.g. dpc-covid19-ita-regioni-20200326.csv )
     timezone = pytz.timezone('UTC')
@@ -753,6 +753,7 @@ def transform_neherlab_population(record):
     new_record = {}
     for key, val in list(record.items()):
         new_key = key
+        new_val = str(val).strip()
         if key == 'populationServed':
             new_key = 'population'
         elif key == 'ageDistribution':
@@ -766,7 +767,35 @@ def transform_neherlab_population(record):
         elif key == 'importsPerDay':
             new_key = 'imports_per_day'
 
-        new_record[new_key] = val
+        new_record[new_key] = new_val
+    return new_record
+
+
+# CSV headers, 4/7/2020:    country	AcuteCare	AcuteCarPer100k	IMCU	ICU 	CriticalCare	CriticalCarePer100k	percentOfTotal	GDP
+def transform_neherlab_icu_capacity(record):
+    new_record = {}
+    for key, val in list(record.items()):
+        key = key.strip()
+        new_key = key
+        new_val = str(val).strip()
+        if key == 'AcuteCare':
+            new_key = 'acute_care'
+        elif key in ('AcuteCarPer100k', 'AcuteCarePer100k'):
+            new_key = 'acute_care_per_100k'
+        elif key == 'IMCU':
+            new_key = 'imcu'
+        elif key == 'ICU':
+            new_key = 'icu'
+        elif key == 'CriticalCare':
+            new_key = 'critical_care'
+        elif key == 'CriticalCarePer100k':
+            new_key = 'critical_care_per_100k'
+        elif key == 'percentOfTotal':
+            new_key = 'percent_of_total'
+        elif key == 'GDP':
+            new_key = 'gdp'
+
+        new_record[new_key] = new_val
     return new_record
 
 
@@ -787,6 +816,8 @@ def transform_record(stream_name, record):
         new_record = transform_neherlab_country_codes(record)
     elif stream_name == 'neherlab_population':
         new_record = transform_neherlab_population(record)
+    elif stream_name == 'neherlab_icu_capacity':
+        new_record = transform_neherlab_icu_capacity(record)
     elif stream_name[:7] == 'c19_trk':
         new_record = transform_c19_trk(record)
 


### PR DESCRIPTION
# Description of change
Change field `row_number` (a reserved word in Redshift) to `__sdc_row_number`. This requires dropping/re-loading tables in downstream target. Added 403 error handling for API Abuse Detection to wait for 3 minutes before resuming requests. Add endpoint: `neherlab_icu_capacity`.

# Manual QA steps
Ran Discover, singer-check-tap, initial load sync, ongoing incremental sync.
 
# Risks
 Medium - currently in beta. Clients will need to re-discover, drop and re-load tables b/c primary keys change from `row_number` to `__sdc_row_number`.
 
# Rollback steps
Revert to v.0.0.7
