### PR TITLE
v.0.0.9 Fix Italian Decoding Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+  * Add `character_set` parameter to `streams.py` and `sync.py` to deal with errors arising from accented characters in the Italian dataset files, which use `latin_1` and not `utf-8`. Fixes error decoding: `Forlì-Cesena`.
+
 ## 0.0.8
   * Change field `row_number` (a reserved word in Redshift) to `__sdc_row_number`. This requires dropping/re-loading tables in downstream target. Added 403 error handling for API Abuse Detection to wait for 2 minutes before resuming requests. Add endpoint: `neherlab_icu_capacity`.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-covid-19',
-      version='0.0.8',
+      version='0.0.9',
       description='Singer.io tap for extracting COVID-19 CSV data files with the GitHub API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_covid_19/streams.py
+++ b/tap_covid_19/streams.py
@@ -10,6 +10,7 @@
 #   params: Query, sort, and other endpoint specific parameters; default = {}
 #   data_key: JSON element containing the results list for the endpoint; default = 'results'
 #   bookmark_query_field: From date-time field used for filtering the query
+#   alt_character_set: Alternate character set to try if UTF-8 decoding does not work
 
 STREAMS = {
     # Reference: https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/us_daily.csv
@@ -147,7 +148,7 @@ STREAMS = {
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
         'bookmark_query_field': 'If-Modified-Since',
-        'character_set': 'latin_1'
+        'alt_character_set': 'latin_1'
     },
     # Dati COVID-19 Italia (COVID-19 data Italy)
     # Reference: https://github.com/pcm-dpc/COVID-19/tree/master/dati-andamento-nazionale
@@ -161,7 +162,7 @@ STREAMS = {
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
         'bookmark_query_field': 'If-Modified-Since',
-        'character_set': 'latin_1'
+        'alt_character_set': 'latin_1'
     },
     # Dati COVID-19 Italia (COVID-19 data Italy)
     # Reference: https://github.com/pcm-dpc/COVID-19
@@ -175,7 +176,7 @@ STREAMS = {
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
         'bookmark_query_field': 'If-Modified-Since',
-        'character_set': 'latin_1'
+        'alt_character_set': 'latin_1'
     },
     # Reference: https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_daily_reports
     # Many files w/ new file each day. Use INCREMENTAL replication only (NOT activate_version)

--- a/tap_covid_19/streams.py
+++ b/tap_covid_19/streams.py
@@ -146,7 +146,8 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
-        'bookmark_query_field': 'If-Modified-Since'
+        'bookmark_query_field': 'If-Modified-Since',
+        'character_set': 'latin_1'
     },
     # Dati COVID-19 Italia (COVID-19 data Italy)
     # Reference: https://github.com/pcm-dpc/COVID-19/tree/master/dati-andamento-nazionale
@@ -159,7 +160,8 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
-        'bookmark_query_field': 'If-Modified-Since'
+        'bookmark_query_field': 'If-Modified-Since',
+        'character_set': 'latin_1'
     },
     # Dati COVID-19 Italia (COVID-19 data Italy)
     # Reference: https://github.com/pcm-dpc/COVID-19
@@ -172,7 +174,8 @@ STREAMS = {
         'replication_method': 'INCREMENTAL',
         'activate_version': False,
         'replication_keys': ['git_last_modified'],
-        'bookmark_query_field': 'If-Modified-Since'
+        'bookmark_query_field': 'If-Modified-Since',
+        'character_set': 'latin_1'
     },
     # Reference: https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_daily_reports
     # Many files w/ new file each day. Use INCREMENTAL replication only (NOT activate_version)

--- a/tap_covid_19/sync.py
+++ b/tap_covid_19/sync.py
@@ -120,6 +120,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     csv_delimiter = endpoint_config.get('csv_delimiter', ',')
     skip_header_rows = endpoint_config.get('skip_header_rows', 0)
     activate_version_ind = endpoint_config.get('activate_version', False)
+    character_set = endpoint_config.get('character_set', 'utf-8')
     # LOGGER.info('data_key = {}'.format(data_key))
 
     # Get the latest bookmark for the stream and set the last_datetime
@@ -252,7 +253,9 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                     content_list = []
                     if content:
                         content_b64 = base64.b64decode(content)
-                        content_str = content_b64.decode('utf-8')
+                        # Italian files use character_set: latin_1
+                        # All other files use character_set: utf-8 (default)
+                        content_str = content_b64.decode(character_set)
                         content_array = content_str.splitlines()
                         content_array_sliced = content_array[skip_header_rows:]
                         reader = csv.DictReader(content_array_sliced, delimiter=csv_delimiter)


### PR DESCRIPTION
# Description of change
Add `character_set` parameter to `streams.py` and `sync.py` to deal with errors arising from accented characters in the Italian dataset files, which use `latin_1` and not `utf-8`. Fixes error decoding: `Forlì-Cesena`.
Error GitHub File: https://github.com/pcm-dpc/COVID-19/blob/67b2b92ed2664c13b09c37a5bc65ab447b4f87b2/dati-province/dpc-covid19-ita-province-20200428.csv

# Manual QA steps
Identified/fixed issue. Ran Discover, singer-check-tap, initial load, and incremental sync for ALL 3 Italian (latin_1 char set) endpoints and 3 non-Italian (default utf-8 char set) endpoints. Verified all endpoints loaded without errors. Verified accented value `Forlì-Cesena` in downstream database.
 
# Risks
Low - minor change that only affects Italian endpoints.
 
# Rollback steps
Revert branch to v.0.0.8
