### PR TITLE
Fix Swiss daily files datetime format

### DIFF
--- a/tap_covid_19/transform.py
+++ b/tap_covid_19/transform.py
@@ -343,7 +343,10 @@ def transform_eu_daily(record):
 
     # Datetime
     dt_str = record.get('datetime')
-    dt = datetime.strptime(dt_str, '%Y-%m-%dT%H:%M:%S')
+    try:
+        dt = datetime.strptime(dt_str, '%Y-%m-%dT%H:%M:%S')
+    except ValueError:
+        dt = datetime.strptime(dt_str, '%Y-%m-%d')
     new_record['datetime'] = dt_str
     new_record['date'] = dt.date()
 


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)
Swiss daily files have a `%H-%m-%d` datetime format. Example: https://github.com/covid19-eu-zh/covid19-eu-data/blob/master/dataset/daily/ch/ch_covid19_2020-05-27_0_00.csv

# Manual QA steps
 - Checked the `eu-daily` stream with `singer-check-tap`:

```shell
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 47724 messages for 1 streams.

      1 schema messages
  47720 record messages
      3 state messages

Details by stream:
+----------+---------+---------+
| stream   | records | schemas |
+----------+---------+---------+
| eu_daily | 47720   | 1       |
+----------+---------+---------+
``` 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
